### PR TITLE
fix potential crash on upstream close

### DIFF
--- a/src/ngx_srt_connection.c
+++ b/src/ngx_srt_connection.c
@@ -1467,6 +1467,7 @@ ngx_srt_conn_finalize(ngx_srt_conn_t *sc, ngx_uint_t rc)
 
         ngx_close_connection(pc);
         st->connection = NULL;
+        st->connected = 0;
         st->close_conn = 0;
     }
 
@@ -1532,6 +1533,7 @@ ngx_srt_conn_terminate(ngx_srt_conn_t *sc)
 
         ngx_close_connection(pc);
         st->connection = NULL;
+        st->connected = 0;
     }
 
     ngx_srt_conn_destroy(sc);


### PR DESCRIPTION
when doing SRT->TCP and TCP upstream closes the conn,
ngx_srt_conn_finalize is called, and it closes the upstream connection.
if a read event is received until the close event reaches the srt
thread, it may try to send to the already closed upstream connection.
setting connected to false, makes ngx_srt_proxy_srt_handler return
early, and prevents the crash.