### PR TITLE
fix input data overrun

### DIFF
--- a/src/ngx_srt_connection.c
+++ b/src/ngx_srt_connection.c
@@ -485,7 +485,7 @@ ngx_srt_conn_in_update_chains(ngx_srt_conn_t *sc, ngx_chain_t *out)
 
     ngx_spinlock(&sc->srt_in.lock, 1, 2048);
 
-    if (sc->srt_in.busy == NULL) {
+    if (sc->srt_in.busy == NULL && sc->srt_in.out == NULL) {
         notify = (b->end - b->last < NGX_SRT_MIN_RECV_SIZE);
         b->last = b->start;
 


### PR DESCRIPTION
in ngx_srt_conn_in_update_chains, it is possible that busy is null, but
out is not, because a call to srt_recv just returned some data.
in this case, the last pointer must not be reset, as it would overwrite
the data which is pointed by the out chain.