### PR TITLE
ngx_srt_listen: call srt_listen_callback() before srt_listen()

### DIFF
--- a/src/ngx_srt_connection.c
+++ b/src/ngx_srt_connection.c
@@ -1948,6 +1948,13 @@ ngx_srt_listen(ngx_cycle_t *cycle, ngx_listening_t *ls, ngx_log_t *error_log,
         return NGX_ERROR;
     }
 
+    if (srt_listen_callback(ss, ngx_srt_listen_callback, sls) != 0) {
+        serr = srt_getlasterror(&serrno);
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, serrno,
+            "ngx_srt_listen: srt_listen_callback() failed %d", serr);
+        return NGX_ERROR;
+    }
+
     if (srt_listen(ss, ls->backlog) != 0) {
         serr = srt_getlasterror(&serrno);
         ngx_log_error(NGX_LOG_EMERG, cycle->log, serrno,
@@ -1971,13 +1978,6 @@ ngx_srt_listen(ngx_cycle_t *cycle, ngx_listening_t *ls, ngx_log_t *error_log,
     if (sls == NULL) {
         ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
             "ngx_srt_listen: ngx_srt_listen: alloc session failed");
-        return NGX_ERROR;
-    }
-
-    if (srt_listen_callback(ss, ngx_srt_listen_callback, sls) != 0) {
-        serr = srt_getlasterror(&serrno);
-        ngx_log_error(NGX_LOG_EMERG, cycle->log, serrno,
-            "ngx_srt_listen: srt_listen_callback() failed %d", serr);
         return NGX_ERROR;
     }
 


### PR DESCRIPTION
With latest libsrt, I found that we can not listen srt succeccfully:
2023/12/19 10:04:15 [emerg] 28#0: ngx_srt_listen: srt_listen_callback() failed 5002
2023/12/19 10:04:15 [alert] 28#0: ngx_srt_thread_create: thread failed to initialize

According to libsrt API doc([srt_listen_callback](https://github.com/Haivision/srt/blob/master/docs/API/API-functions.md#srt_listen_callback) ), we must NOT call srt_listen_callback()  on a 'connected' socket. So we need to call srt_listen_callback() before srt_listen().